### PR TITLE
Add default tag mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ events"](#hapievents) section.
 - `[tags]` - a map to specify pairs of Hapi log tags and levels. By default,
   the tags *trace*, *debug*, *info*, *warn*, and *error* map to their
   corresponding level. Any mappings you supply take precedence over the default
-  mappings.
+  mappings. The default level tags are exposed via `hapi-pino.levelTags`.
 - `[allTags]` - the logging level to apply to all tags not matched by
   `tags`, defaults to `'info'`.
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,10 @@ events"](#hapievents) section.
 - `[prettyPrint]` - pretty print the logs (same as `node server |
   pino`), disable in production. Default is `false`, enable in
   development by passing `true`.
-- `[tags]` - a map to specify pairs of Hapi log tags and levels.
+- `[tags]` - a map to specify pairs of Hapi log tags and levels. By default,
+  the tags *trace*, *debug*, *info*, *warn*, and *error* map to their
+  corresponding level. Any mappings you supply take precedence over the default
+  mappings.
 - `[allTags]` - the logging level to apply to all tags not matched by
   `tags`, defaults to `'info'`.
 

--- a/index.js
+++ b/index.js
@@ -11,13 +11,14 @@ function register (server, options, next) {
   options.serializers.res = pino.stdSerializers.res
   options.serializers.err = pino.stdSerializers.err
 
-  const tagToLevels = Object.assign({}, {
+  module.exports.levelTags = {
     trace: 'trace',
     debug: 'debug',
     info: 'info',
     warn: 'warn',
     error: 'error'
-  }, options.tags)
+  }
+  const tagToLevels = Object.assign({}, module.exports.levelTags, options.tags)
   const allTags = options.allTags || 'info'
 
   const validTags = Object.keys(tagToLevels).filter((key) => levels.indexOf(tagToLevels[key]) < 0).length === 0

--- a/index.js
+++ b/index.js
@@ -11,13 +11,13 @@ function register (server, options, next) {
   options.serializers.res = pino.stdSerializers.res
   options.serializers.err = pino.stdSerializers.err
 
-  const tagToLevels = options.tags || {
+  const tagToLevels = Object.assign({}, {
     trace: 'trace',
     debug: 'debug',
     info: 'info',
     warn: 'warn',
     error: 'error'
-  }
+  }, options.tags)
   const allTags = options.allTags || 'info'
 
   const validTags = Object.keys(tagToLevels).filter((key) => levels.indexOf(tagToLevels[key]) < 0).length === 0

--- a/index.js
+++ b/index.js
@@ -3,6 +3,13 @@
 const pino = require('pino')
 
 const levels = ['trace', 'debug', 'info', 'warn', 'error']
+module.exports.levelTags = {
+  trace: 'trace',
+  debug: 'debug',
+  info: 'info',
+  warn: 'warn',
+  error: 'error'
+}
 
 function register (server, options, next) {
   options.stream = options.stream || process.stdout
@@ -11,13 +18,6 @@ function register (server, options, next) {
   options.serializers.res = pino.stdSerializers.res
   options.serializers.err = pino.stdSerializers.err
 
-  module.exports.levelTags = {
-    trace: 'trace',
-    debug: 'debug',
-    info: 'info',
-    warn: 'warn',
-    error: 'error'
-  }
   const tagToLevels = Object.assign({}, module.exports.levelTags, options.tags)
   const allTags = options.allTags || 'info'
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,13 @@ function register (server, options, next) {
   options.serializers.res = pino.stdSerializers.res
   options.serializers.err = pino.stdSerializers.err
 
-  const tagToLevels = options.tags || {}
+  const tagToLevels = options.tags || {
+    trace: 'trace',
+    debug: 'debug',
+    info: 'info',
+    warn: 'warn',
+    error: 'error'
+  }
   const allTags = options.allTags || 'info'
 
   const validTags = Object.keys(tagToLevels).filter((key) => levels.indexOf(tagToLevels[key]) < 0).length === 0

--- a/test.js
+++ b/test.js
@@ -324,4 +324,25 @@ experiment('logs through request.log', () => {
       server.inject('/')
     })
   })
+
+  test('uses default tag mapping', (done) => {
+    const server = getServer()
+    const stream = sink((data) => {
+      expect(data.data).to.equal('hello world')
+      expect(data.level).to.equal(20)
+      done()
+    })
+    const plugin = {
+      register: Pino.register,
+      options: {
+        stream: stream,
+        level: 'debug'
+      }
+    }
+
+    server.register(plugin, (err) => {
+      expect(err).to.be.undefined()
+      server.log(['debug'], 'hello world')
+    })
+  })
 })


### PR DESCRIPTION
This PR adds default mappings for tags to log levels. This reduces the amount of configuration necessary to use the plugin in a standard logging style.