### PR TITLE
Add support for using prior Pino instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ events"](#hapievents) section.
 - `[tags]` - a map to specify pairs of Hapi log tags and levels.
 - `[allTags]` - the logging level to apply to all tags not matched by
   `tags`, defaults to `'info'`.
+- `[instance]` - uses a previously created Pino instance as the logger.
+  The instance's `stream` and `serializers` take precedence.
 
 
 <a name="serverdecorations"></a>

--- a/index.js
+++ b/index.js
@@ -5,11 +5,27 @@ const pino = require('pino')
 const levels = ['trace', 'debug', 'info', 'warn', 'error']
 
 function register (server, options, next) {
-  options.stream = options.stream || process.stdout
   options.serializers = options.serializers || {}
   options.serializers.req = asReqValue
   options.serializers.res = pino.stdSerializers.res
   options.serializers.err = pino.stdSerializers.err
+
+  let logger
+  if (options.instance) {
+    options.instance.serializers = Object.assign(options.serializers, options.instance.serializers)
+    logger = options.instance
+  } else {
+    options.stream = options.stream || process.stdout
+    let stream = options.stream || process.stdout
+
+    if (options.prettyPrint) {
+      let pretty = pino.pretty()
+      pretty.pipe(stream)
+      stream = pretty
+    }
+
+    logger = pino(options, stream)
+  }
 
   const tagToLevels = options.tags || {}
   const allTags = options.allTags || 'info'
@@ -18,16 +34,6 @@ function register (server, options, next) {
   if (!validTags || allTags && levels.indexOf(allTags) < 0) {
     return next(new Error('invalid tag levels'))
   }
-
-  let stream = options.stream || process.stdout
-
-  if (options.prettyPrint) {
-    let pretty = pino.pretty()
-    pretty.pipe(stream)
-    stream = pretty
-  }
-
-  const logger = pino(options, stream)
 
   // expose logger as 'server.app.logger'
   server.app.logger = logger

--- a/test.js
+++ b/test.js
@@ -325,3 +325,56 @@ experiment('logs through request.log', () => {
     })
   })
 })
+
+experiment('uses a prior pino instance', () => {
+  test('without pre-defined serializers', (done) => {
+    const server = getServer()
+    const stream = sink((data) => {
+      expect(data.data).to.equal('hello world')
+      expect(data.level).to.equal(30)
+      done()
+    })
+    const logger = require('pino')(stream)
+    const plugin = {
+      register: Pino.register,
+      options: {
+        instance: logger
+      }
+    }
+
+    server.register(plugin, (err) => {
+      expect(err).to.be.undefined()
+      server.log(['something'], 'hello world')
+    })
+  })
+
+  test('with pre-defined serializers', (done) => {
+    const server = getServer()
+    const stream = sink((data) => {
+      expect(data.msg).to.equal('hello world')
+      expect(data.foo).to.exist()
+      expect(data.foo.serializedFoo).to.exist()
+      expect(data.foo.serializedFoo).to.equal('foo is bar')
+      expect(data.level).to.equal(30)
+      done()
+    })
+    const logger = require('pino')({
+      serializers: {
+        foo: (input) => {
+          return { serializedFoo: `foo is ${input}` }
+        }
+      }
+    }, stream)
+    const plugin = {
+      register: Pino.register,
+      options: {
+        instance: logger
+      }
+    }
+
+    server.register(plugin, (err) => {
+      expect(err).to.be.undefined()
+      server.app.logger.info({foo: 'bar'}, 'hello world')
+    })
+  })
+})


### PR DESCRIPTION
If you have previously created an instance of Pino, prior to initializing your Hapi instance, it should be possible to use that instance of Pino within the plugin. This PR adds such support.